### PR TITLE
Add PlatformIO CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: PlatformIO CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade platformio
-        pio lib -g install "adafruit/DHT sensor library@^1.4.3"
+        pio lib -g install "beegee-tokyo/DHT sensor library for ESPx@^1.18"
     - name: Run PlatformIO
-      run: pio ci --board=esp32dev
+      run: pio ci --lib="." --board=esp32dev
       env:
         PLATFORMIO_CI_SRC: ${{ matrix.example }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade platformio
-        pio lib -g install "beegee-tokyo/DHT sensor library for ESPx@^1.18"
+        pio pkg install -g -l "adafruit/DHT sensor library@^1.4.3"
     - name: Run PlatformIO
       run: pio ci --lib="." --board=esp32dev
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade platformio
-        pio pkg install -g -l "adafruit/DHT sensor library@^1.4.3"
+        pio pkg install -g -l "adafruit/DHT sensor library@^1.4.3" -l "adafruit/Adafruit Unified Sensor@^1.1.5"
     - name: Run PlatformIO
       run: pio ci --lib="." --board=esp32dev
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,6 @@ jobs:
         pip install --upgrade platformio
         pio pkg install -g -l "adafruit/DHT sensor library@^1.4.3" -l "adafruit/Adafruit Unified Sensor@^1.1.5"
     - name: Run PlatformIO
-      run: pio ci --lib="." --board=esp32dev
+      run: pio ci --lib="." --board=esp32dev -O "lib_ldf_mode = chain+"
       env:
         PLATFORMIO_CI_SRC: ${{ matrix.example }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: PlatformIO CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        example: [examples/ESP32-CoT-switch_light/ESP32-CoT-switch_light.ino, examples/ESP32-CoT-write_temp_and_hum/ESP32-CoT-write_temp_and_hum.ino]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: ${{ runner.os }}-pip-
+    - name: Cache PlatformIO
+      uses: actions/cache@v2
+      with:
+        path: ~/.platformio
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+    - name: Set up Python
+      uses: actions/setup-python@v2
+    - name: Install PlatformIO
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade platformio
+        pio lib -g install "adafruit/DHT sensor library@^1.4.3"
+    - name: Run PlatformIO
+      run: pio ci --board=esp32dev
+      env:
+        PLATFORMIO_CI_SRC: ${{ matrix.example }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,6 @@ jobs:
         pip install --upgrade platformio
         pio pkg install -g -l "adafruit/DHT sensor library@^1.4.3" -l "adafruit/Adafruit Unified Sensor@^1.1.5"
     - name: Run PlatformIO
-      run: pio ci --lib="." --board=esp32dev -O "lib_ldf_mode = chain+"
+      run: pio ci --lib="." --board=esp32dev -O "lib_ldf_mode = chain+" -O "lib_deps = Adafruit Unified Sensor"
       env:
         PLATFORMIO_CI_SRC: ${{ matrix.example }}


### PR DESCRIPTION
Adds a Github Workflow as shown in the [PlatformIO docs](https://docs.platformio.org/en/latest/integration/ci/github-actions.html#integration) to test the examples for actual compilability.

Successfully builds both examples and adds the nice green checkmark to the commit.

(**Squash** commits upon merging, no need for these 6 unnamed commits to go in separately)